### PR TITLE
Implement temperature probe calculator with lookup table

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,6 +632,11 @@
                 <h3>🔢 Simple Calculator</h3>
                 <p>Calcolatrice standard per operazioni base</p>
             </div>
+            
+            <div class="menu-item" onclick="showCalculator('tempprobe')">
+                <h3>🌡️ Temp Probe Calculator</h3>
+                <p>Calcola temperatura/resistenza per sonde NTC e PT</p>
+            </div>
         </div>
     </div>
 
@@ -1022,6 +1027,61 @@
         </div>
     </div>
 
+    <!-- Temperature Probe Calculator -->
+    <div class="calculator" id="tempprobe-calculator">
+        <div class="calculator-header">
+            <div class="calculator-title">🌡️ Temp Probe Calculator</div>
+            <button class="back-btn" onclick="showMenu()">← Menu</button>
+        </div>
+        
+        <div class="input-group">
+            <label for="tp_input_type">Input Type</label>
+            <select id="tp_input_type" onchange="toggleInputFields()">
+                <option value="temperature">Temperature → Resistance</option>
+                <option value="resistance">Resistance → Temperature</option>
+            </select>
+        </div>
+        
+        <div class="input-group">
+            <label for="tp_probe_type">Probe Type</label>
+            <select id="tp_probe_type">
+                <option value="ntc3k3">NTC 3.3kΩ @ 25°C</option>
+                <option value="ntc47k">NTC 47kΩ @ 25°C</option>
+                <option value="pt1000">PT1000 (1000Ω @ 0°C)</option>
+                <option value="pt100">PT100 (100Ω @ 0°C)</option>
+            </select>
+        </div>
+        
+        <div class="input-group" id="temp_input_group">
+            <label for="tp_temperature">Temperature (°C)</label>
+            <input type="number" id="tp_temperature" placeholder="Enter temperature (0-200°C)" step="0.1" min="0" max="200">
+        </div>
+        
+        <div class="input-group" id="resistance_input_group" style="display: none;">
+            <label for="tp_resistance">Resistance (Ω)</label>
+            <input type="number" id="tp_resistance" placeholder="Enter resistance value" step="0.01" min="0">
+        </div>
+        
+        <button class="calculate-btn" onclick="calculateTempProbe()">Calculate</button>
+        
+        <div class="result-box" id="tempprobe-result" style="display: none;">
+            <h3>Result</h3>
+            <div class="result-item">
+                <span class="result-label" id="tp_result_label">Resistance:</span>
+                <span class="result-value" id="tp_result_value">-</span>
+                <span class="result-unit" id="tp_result_unit">Ω</span>
+            </div>
+            <div class="result-info">
+                <p id="tp_result_info">Enter values above to calculate</p>
+            </div>
+        </div>
+        
+        <div class="reset-container">
+            <button class="reset-btn" onclick="resetTempProbe()">Reset</button>
+        </div>
+    </div>
+
+    <script src="temp_probe_data.js"></script>
     <script>
         // Unit conversion functions
         function convertSurfaceArea(prefix) {
@@ -1154,6 +1214,8 @@
             
             if (type === 'simple') {
                 document.getElementById('simple-calculator').classList.add('active');
+            } else if (type === 'tempprobe') {
+                document.getElementById('tempprobe-calculator').classList.add('active');
             } else {
                 document.getElementById(type + '-calculator').classList.add('active');
             }
@@ -1786,6 +1848,143 @@
         document.body.addEventListener('touchmove', function(e) {
             // Allow all touch movements for scrolling
         }, { passive: true });
+
+        // Temperature Probe Calculator Functions
+        function toggleInputFields() {
+            const inputType = document.getElementById('tp_input_type').value;
+            const tempGroup = document.getElementById('temp_input_group');
+            const resistanceGroup = document.getElementById('resistance_input_group');
+            
+            if (inputType === 'temperature') {
+                tempGroup.style.display = 'block';
+                resistanceGroup.style.display = 'none';
+                document.getElementById('tp_temperature').value = '';
+                document.getElementById('tp_resistance').value = '';
+            } else {
+                tempGroup.style.display = 'none';
+                resistanceGroup.style.display = 'block';
+                document.getElementById('tp_temperature').value = '';
+                document.getElementById('tp_resistance').value = '';
+            }
+            
+            // Hide result when switching input types
+            document.getElementById('tempprobe-result').style.display = 'none';
+        }
+
+        function calculateTempProbe() {
+            const inputType = document.getElementById('tp_input_type').value;
+            const probeType = document.getElementById('tp_probe_type').value;
+            const resultDiv = document.getElementById('tempprobe-result');
+            const resultLabel = document.getElementById('tp_result_label');
+            const resultValue = document.getElementById('tp_result_value');
+            const resultUnit = document.getElementById('tp_result_unit');
+            const resultInfo = document.getElementById('tp_result_info');
+            
+            if (!window.TEMP_PROBE_DATA || !window.interpolateValue) {
+                resultInfo.textContent = 'Error: Temperature probe data not loaded';
+                resultDiv.style.display = 'block';
+                return;
+            }
+            
+            const probeData = window.TEMP_PROBE_DATA[probeType];
+            if (!probeData) {
+                resultInfo.textContent = 'Error: Invalid probe type selected';
+                resultDiv.style.display = 'block';
+                return;
+            }
+            
+            try {
+                if (inputType === 'temperature') {
+                    // Temperature to Resistance
+                    const temperature = parseFloat(document.getElementById('tp_temperature').value);
+                    
+                    if (isNaN(temperature)) {
+                        resultInfo.textContent = 'Please enter a valid temperature value';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    if (temperature < 0 || temperature > 200) {
+                        resultInfo.textContent = 'Temperature must be between 0°C and 200°C';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    const resistance = window.interpolateValue(probeData, temperature, true);
+                    
+                    if (resistance === null) {
+                        resultInfo.textContent = 'Unable to calculate resistance for this temperature';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    resultLabel.textContent = 'Resistance:';
+                    resultValue.textContent = resistance.toFixed(2);
+                    resultUnit.textContent = 'Ω';
+                    resultInfo.textContent = `At ${temperature}°C, the ${getProbeDescription(probeType)} has a resistance of ${resistance.toFixed(2)}Ω`;
+                    
+                } else {
+                    // Resistance to Temperature
+                    const resistance = parseFloat(document.getElementById('tp_resistance').value);
+                    
+                    if (isNaN(resistance)) {
+                        resultInfo.textContent = 'Please enter a valid resistance value';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    if (resistance <= 0) {
+                        resultInfo.textContent = 'Resistance must be greater than 0';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    const temperature = window.interpolateValue(probeData, resistance, false);
+                    
+                    if (temperature === null) {
+                        resultInfo.textContent = 'Unable to calculate temperature for this resistance value';
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    if (temperature < 0 || temperature > 200) {
+                        resultInfo.textContent = `Calculated temperature (${temperature.toFixed(1)}°C) is outside the valid range (0-200°C)`;
+                        resultDiv.style.display = 'block';
+                        return;
+                    }
+                    
+                    resultLabel.textContent = 'Temperature:';
+                    resultValue.textContent = temperature.toFixed(1);
+                    resultUnit.textContent = '°C';
+                    resultInfo.textContent = `With a resistance of ${resistance}Ω, the ${getProbeDescription(probeType)} indicates ${temperature.toFixed(1)}°C`;
+                }
+                
+                resultDiv.style.display = 'block';
+                
+            } catch (error) {
+                resultInfo.textContent = 'Error calculating result: ' + error.message;
+                resultDiv.style.display = 'block';
+            }
+        }
+
+        function getProbeDescription(probeType) {
+            const descriptions = {
+                'ntc3k3': 'NTC 3.3kΩ probe',
+                'ntc47k': 'NTC 47kΩ probe', 
+                'pt1000': 'PT1000 probe',
+                'pt100': 'PT100 probe'
+            };
+            return descriptions[probeType] || 'probe';
+        }
+
+        function resetTempProbe() {
+            document.getElementById('tp_input_type').value = 'temperature';
+            document.getElementById('tp_probe_type').value = 'ntc3k3';
+            document.getElementById('tp_temperature').value = '';
+            document.getElementById('tp_resistance').value = '';
+            document.getElementById('tempprobe-result').style.display = 'none';
+            toggleInputFields();
+        }
     </script>
 </body>
 </html> 

--- a/temp_probe_data.js
+++ b/temp_probe_data.js
@@ -1,0 +1,263 @@
+// Temperature Probe Data - Resistance values for different probe types
+// Temperature range: 0°C to 200°C
+
+const TEMP_PROBE_DATA = {
+    // NTC 3.3k ohm at 25°C (using Steinhart-Hart equation approximation)
+    'ntc3k3': {
+        0: 10470,    // 0°C
+        5: 8317,     // 5°C
+        10: 6653,    // 10°C
+        15: 5361,    // 15°C
+        20: 4350,    // 20°C
+        25: 3300,    // 25°C (nominal)
+        30: 2668,    // 30°C
+        35: 2174,    // 35°C
+        40: 1782,    // 40°C
+        45: 1468,    // 45°C
+        50: 1214,    // 50°C
+        55: 1010,    // 55°C
+        60: 844,     // 60°C
+        65: 708,     // 65°C
+        70: 597,     // 70°C
+        75: 505,     // 75°C
+        80: 429,     // 80°C
+        85: 366,     // 85°C
+        90: 314,     // 90°C
+        95: 270,     // 95°C
+        100: 233,    // 100°C
+        105: 202,    // 105°C
+        110: 176,    // 110°C
+        115: 154,    // 115°C
+        120: 135,    // 120°C
+        125: 119,    // 125°C
+        130: 105,    // 130°C
+        135: 93,     // 135°C
+        140: 83,     // 140°C
+        145: 74,     // 145°C
+        150: 66,     // 150°C
+        155: 59,     // 155°C
+        160: 53,     // 160°C
+        165: 48,     // 165°C
+        170: 43,     // 170°C
+        175: 39,     // 175°C
+        180: 35,     // 180°C
+        185: 32,     // 185°C
+        190: 29,     // 190°C
+        195: 26,     // 195°C
+        200: 24      // 200°C
+    },
+
+    // NTC 47k ohm at 25°C
+    'ntc47k': {
+        0: 149300,   // 0°C
+        5: 118600,   // 5°C
+        10: 94850,   // 10°C
+        15: 76520,   // 15°C
+        20: 62050,   // 20°C
+        25: 47000,   // 25°C (nominal)
+        30: 38060,   // 30°C
+        35: 31010,   // 35°C
+        40: 25410,   // 40°C
+        45: 20940,   // 45°C
+        50: 17330,   // 50°C
+        55: 14410,   // 55°C
+        60: 12040,   // 60°C
+        65: 10110,   // 65°C
+        70: 8520,    // 70°C
+        75: 7210,    // 75°C
+        80: 6120,    // 80°C
+        85: 5220,    // 85°C
+        90: 4470,    // 90°C
+        95: 3840,    // 95°C
+        100: 3320,   // 100°C
+        105: 2880,   // 105°C
+        110: 2510,   // 110°C
+        115: 2190,   // 115°C
+        120: 1920,   // 120°C
+        125: 1690,   // 125°C
+        130: 1490,   // 130°C
+        135: 1320,   // 135°C
+        140: 1170,   // 140°C
+        145: 1040,   // 145°C
+        150: 930,    // 150°C
+        155: 830,    // 155°C
+        160: 745,    // 160°C
+        165: 670,    // 165°C
+        170: 605,    // 170°C
+        175: 545,    // 175°C
+        180: 495,    // 180°C
+        185: 450,    // 185°C
+        190: 410,    // 190°C
+        195: 375,    // 195°C
+        200: 340     // 200°C
+    },
+
+    // PT1000 (Platinum RTD, 1000 ohm at 0°C)
+    'pt1000': {
+        0: 1000.0,   // 0°C (nominal)
+        5: 1019.5,   // 5°C
+        10: 1039.0,  // 10°C
+        15: 1058.5,  // 15°C
+        20: 1078.0,  // 20°C
+        25: 1097.5,  // 25°C
+        30: 1117.0,  // 30°C
+        35: 1136.5,  // 35°C
+        40: 1156.0,  // 40°C
+        45: 1175.5,  // 45°C
+        50: 1195.0,  // 50°C
+        55: 1214.5,  // 55°C
+        60: 1234.0,  // 60°C
+        65: 1253.5,  // 65°C
+        70: 1273.0,  // 70°C
+        75: 1292.5,  // 75°C
+        80: 1312.0,  // 80°C
+        85: 1331.5,  // 85°C
+        90: 1351.0,  // 90°C
+        95: 1370.5,  // 95°C
+        100: 1390.0, // 100°C
+        105: 1409.5, // 105°C
+        110: 1429.0, // 110°C
+        115: 1448.5, // 115°C
+        120: 1468.0, // 120°C
+        125: 1487.5, // 125°C
+        130: 1507.0, // 130°C
+        135: 1526.5, // 135°C
+        140: 1546.0, // 140°C
+        145: 1565.5, // 145°C
+        150: 1585.0, // 150°C
+        155: 1604.5, // 155°C
+        160: 1624.0, // 160°C
+        165: 1643.5, // 165°C
+        170: 1663.0, // 170°C
+        175: 1682.5, // 175°C
+        180: 1702.0, // 180°C
+        185: 1721.5, // 185°C
+        190: 1741.0, // 190°C
+        195: 1760.5, // 195°C
+        200: 1780.0  // 200°C
+    },
+
+    // PT100 (Platinum RTD, 100 ohm at 0°C)
+    'pt100': {
+        0: 100.00,   // 0°C (nominal)
+        5: 101.95,   // 5°C
+        10: 103.90,  // 10°C
+        15: 105.85,  // 15°C
+        20: 107.80,  // 20°C
+        25: 109.75,  // 25°C
+        30: 111.70,  // 30°C
+        35: 113.65,  // 35°C
+        40: 115.60,  // 40°C
+        45: 117.55,  // 45°C
+        50: 119.50,  // 50°C
+        55: 121.45,  // 55°C
+        60: 123.40,  // 60°C
+        65: 125.35,  // 65°C
+        70: 127.30,  // 70°C
+        75: 129.25,  // 75°C
+        80: 131.20,  // 80°C
+        85: 133.15,  // 85°C
+        90: 135.10,  // 90°C
+        95: 137.05,  // 95°C
+        100: 139.00, // 100°C
+        105: 140.95, // 105°C
+        110: 142.90, // 110°C
+        115: 144.85, // 115°C
+        120: 146.80, // 120°C
+        125: 148.75, // 125°C
+        130: 150.70, // 130°C
+        135: 152.65, // 135°C
+        140: 154.60, // 140°C
+        145: 156.55, // 145°C
+        150: 158.50, // 150°C
+        155: 160.45, // 155°C
+        160: 162.40, // 160°C
+        165: 164.35, // 165°C
+        170: 166.30, // 170°C
+        175: 168.25, // 175°C
+        180: 170.20, // 180°C
+        185: 172.15, // 185°C
+        190: 174.10, // 190°C
+        195: 176.05, // 195°C
+        200: 178.00  // 200°C
+    }
+};
+
+// Function to interpolate between known values
+function interpolateValue(data, targetValue, searchByTemp = true) {
+    const entries = Object.entries(data).map(([key, value]) => [parseFloat(key), value]);
+    entries.sort((a, b) => a[0] - b[0]);
+    
+    if (searchByTemp) {
+        // Find temperature for given resistance
+        const temp = targetValue;
+        if (data[temp] !== undefined) {
+            return data[temp];
+        }
+        
+        // Find closest temperatures for interpolation
+        let lower = null, upper = null;
+        for (const [tempKey, resistance] of entries) {
+            if (tempKey <= temp) {
+                lower = [tempKey, resistance];
+            } else if (tempKey > temp && upper === null) {
+                upper = [tempKey, resistance];
+                break;
+            }
+        }
+        
+        if (lower && upper) {
+            const ratio = (temp - lower[0]) / (upper[0] - lower[0]);
+            return lower[1] + ratio * (upper[1] - lower[1]);
+        }
+        
+        return lower ? lower[1] : (upper ? upper[1] : null);
+    } else {
+        // Find temperature for given resistance
+        const resistance = targetValue;
+        
+        // Find closest resistances for interpolation
+        let lower = null, upper = null;
+        for (const [temp, res] of entries) {
+            if (res >= resistance) {
+                if (lower === null || res < lower[1]) {
+                    upper = lower;
+                    lower = [temp, res];
+                } else if (upper === null || res < upper[1]) {
+                    upper = [temp, res];
+                }
+            } else {
+                if (upper === null || res > upper[1]) {
+                    lower = upper;
+                    upper = [temp, res];
+                } else if (lower === null || res > lower[1]) {
+                    lower = [temp, res];
+                }
+            }
+        }
+        
+        // For NTC thermistors, resistance decreases with temperature
+        // For PT sensors, resistance increases with temperature
+        const isNTC = Object.keys(data)[0] !== undefined && data[0] > data[25];
+        
+        if (isNTC) {
+            // Swap if needed for NTC
+            if (lower && upper && lower[1] < upper[1]) {
+                [lower, upper] = [upper, lower];
+            }
+        }
+        
+        if (lower && upper && lower[1] !== upper[1]) {
+            const ratio = (resistance - upper[1]) / (lower[1] - upper[1]);
+            return upper[0] + ratio * (lower[0] - upper[0]);
+        }
+        
+        return lower ? lower[0] : (upper ? upper[0] : null);
+    }
+}
+
+// Export for use in the calculator
+if (typeof window !== 'undefined') {
+    window.TEMP_PROBE_DATA = TEMP_PROBE_DATA;
+    window.interpolateValue = interpolateValue;
+}


### PR DESCRIPTION
Add a Temperature Probe Calculator to convert between temperature and resistance for NTC and PT probes.

---

[Open in Web](https://cursor.com/agents?id=bc-b9a85ba1-3861-45ce-b1fe-6b2d1b53dbcc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b9a85ba1-3861-45ce-b1fe-6b2d1b53dbcc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)